### PR TITLE
Link to correct ivy-fuz repository

### DIFF
--- a/README.org
+++ b/README.org
@@ -44,7 +44,7 @@ Add this snippet to your =.emacs.d= to make compilation automatically
 #+END_SRC
 *** Ivy
 
-    Please see [[https://github.com/Silex/fuz.el][Silex's fork]].
+    Please see [[https://github.com/Silex/ivy-fuz.el]].
 *** Company (WIP)
 ** Using fuz's score/match function in your Elisp
 *** TODO Add documentation here


### PR DESCRIPTION
You linked to the fork, but given the repositories are completely different a fork makes no sense.